### PR TITLE
Feat: [BADA-49] 렌탈 관련 엔티티 생성 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 
 	//SWAGGER
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// hibernate-spatial
+	implementation 'org.hibernate.orm:hibernate-spatial'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/DeviceReservation.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/DeviceReservation.java
@@ -1,0 +1,51 @@
+package com.TwoSeaU.BaData.domain.rental.entity;
+
+import com.TwoSeaU.BaData.domain.store.entity.StoreDevice;
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class DeviceReservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_device_id", nullable = false)
+    private StoreDevice storeDevice;
+
+    @Column(nullable = false)
+    private int reservationCount;
+
+    public DeviceReservation of(final Reservation reservation, final StoreDevice storeDevice,final int reservationCount){
+
+        return DeviceReservation
+                .builder()
+                .reservation(reservation)
+                .storeDevice(storeDevice)
+                .reservationCount(reservationCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/DeviceReservation.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/DeviceReservation.java
@@ -36,9 +36,9 @@ public class DeviceReservation extends BaseEntity {
     private StoreDevice storeDevice;
 
     @Column(nullable = false)
-    private int reservationCount;
+    private Integer reservationCount;
 
-    public DeviceReservation of(final Reservation reservation, final StoreDevice storeDevice,final int reservationCount){
+    public DeviceReservation of(final Reservation reservation, final StoreDevice storeDevice,final Integer reservationCount){
 
         return DeviceReservation
                 .builder()

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/QuickReply.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/QuickReply.java
@@ -1,0 +1,33 @@
+package com.TwoSeaU.BaData.domain.rental.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+public class QuickReply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    public static QuickReply of(final String name){
+
+        return QuickReply.builder()
+                .name(name)
+                .build();
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Reservation.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Reservation.java
@@ -1,0 +1,59 @@
+package com.TwoSeaU.BaData.domain.rental.entity;
+
+import com.TwoSeaU.BaData.domain.rental.enums.ReservationStatus;
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime rentalStartDate;
+
+    @Column(nullable = false)
+    private LocalDateTime rentalEndDate;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+    public static Reservation of(final User user, final LocalDateTime rentalStartDate, final LocalDateTime rentalEndDate){
+
+        return Reservation.builder()
+                .user(user)
+                .rentalStartDate(rentalStartDate)
+                .rentalEndDate(rentalEndDate)
+                .status(ReservationStatus.PENDING)
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Review.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Review.java
@@ -1,0 +1,58 @@
+package com.TwoSeaU.BaData.domain.rental.entity;
+
+import com.TwoSeaU.BaData.domain.store.entity.Store;
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @Column(nullable = false)
+    private String content;
+
+    private int rating;
+
+    private String imageUrl;
+
+    public static Review of(final Store store, final Reservation reservation, final String content, final int rating,
+                            final String imageUrl){
+
+        return Review.builder()
+                .store(store)
+                .reservation(reservation)
+                .content(content)
+                .rating(rating)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Review.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Review.java
@@ -39,11 +39,11 @@ public class Review extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    private int rating;
+    private Integer rating;
 
     private String imageUrl;
 
-    public static Review of(final Store store, final Reservation reservation, final String content, final int rating,
+    public static Review of(final Store store, final Reservation reservation, final String content, final Integer rating,
                             final String imageUrl){
 
         return Review.builder()

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/ReviewQuickReply.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/ReviewQuickReply.java
@@ -1,0 +1,43 @@
+package com.TwoSeaU.BaData.domain.rental.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class ReviewQuickReply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quick_reply_id", nullable = false)
+    private QuickReply quickReply;
+
+    public static ReviewQuickReply of(final Review review, final QuickReply quickReply){
+
+        return ReviewQuickReply.builder()
+                .review(review)
+                .quickReply(quickReply)
+                .build();
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/enums/ReservationStatus.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/enums/ReservationStatus.java
@@ -1,0 +1,15 @@
+package com.TwoSeaU.BaData.domain.rental.enums;
+
+
+import lombok.Getter;
+
+@Getter
+public enum ReservationStatus {
+
+    PENDING("수령 전"),BURROWING("대여 중"),COMPLETE("완료");
+
+    private final String value;
+    ReservationStatus(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/enums/ReservationStatus.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/enums/ReservationStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public enum ReservationStatus {
 
-    PENDING("수령 전"),BURROWING("대여 중"),COMPLETE("완료");
+    PENDING("수령 전"), BURROWING("대여 중"), COMPLETE("완료");
 
     private final String value;
     ReservationStatus(String value) {

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/DeviceReservationRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/DeviceReservationRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import com.TwoSeaU.BaData.domain.rental.entity.DeviceReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceReservationRepository extends JpaRepository<DeviceReservation,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/QuickReplyRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/QuickReplyRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import com.TwoSeaU.BaData.domain.rental.entity.QuickReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuickReplyRepository extends JpaRepository<QuickReply,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import com.TwoSeaU.BaData.domain.rental.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReviewQuickReplyRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReviewQuickReplyRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import com.TwoSeaU.BaData.domain.rental.entity.ReviewQuickReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewQuickReplyRepository extends JpaRepository<ReviewQuickReply,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReviewRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import com.TwoSeaU.BaData.domain.rental.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/entity/Device.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/entity/Device.java
@@ -1,0 +1,49 @@
+package com.TwoSeaU.BaData.domain.store.entity;
+
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class Device extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private Integer dataMaxSpeed;//Mbps 기준
+
+    private Integer supportDevicesCount;
+
+    @Column(nullable = false)
+    private Boolean is5G;
+
+    private String imageUrl;
+
+    public static Device of(final String name, final Integer dataMaxSpeed, final Integer supportDevicesCount,
+                             final Boolean is5G, final String imageUrl){
+
+        return Device.builder()
+                .name(name)
+                .dataMaxSpeed(dataMaxSpeed)
+                .supportDevicesCount(supportDevicesCount)
+                .is5G(is5G)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/entity/ReStock.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/entity/ReStock.java
@@ -1,0 +1,44 @@
+package com.TwoSeaU.BaData.domain.store.entity;
+
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class ReStock extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_device_id", nullable = false)
+    private StoreDevice storeDevice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public ReStock of(final StoreDevice storeDevice, final User user){
+
+        return ReStock.builder()
+                .user(user)
+                .storeDevice(storeDevice)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/entity/Store.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/entity/Store.java
@@ -1,0 +1,66 @@
+package com.TwoSeaU.BaData.domain.store.entity;
+
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class Store extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "geometry(Point, 4326)")
+    private Point position;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private Integer availableDevice;
+
+    @Column(nullable = false)
+    private String detailAddress;
+
+    private String storeImage;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private LocalTime endTime;
+
+    public static Store of(final String name, final Point position,final String phoneNumber, final String detailAddress,
+                            final Integer availableDevice, final String storeImage, final LocalTime startTime, final LocalTime endTime){
+
+        return Store.builder()
+                .name(name)
+                .position(position)
+                .phoneNumber(phoneNumber)
+                .availableDevice(availableDevice)
+                .detailAddress(detailAddress)
+                .storeImage(storeImage)
+                .startTime(startTime)
+                .endTime(endTime)
+                .build();
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/entity/StoreDevice.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/entity/StoreDevice.java
@@ -1,0 +1,56 @@
+package com.TwoSeaU.BaData.domain.store.entity;
+
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class StoreDevice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "device_id", nullable = false)
+    private Device device;
+
+    @Column(nullable = false)
+    private int count;
+
+    @Column(nullable = false)
+    private int price; // 1일 대여 가격
+
+    @Column(nullable = false)
+    private int dataCapacity; // 1일 데이터 한도 => 무제한은 999로 표기
+
+    public static StoreDevice of(final Store store, final Device device, final int count, final int price, final int dataCapacity){
+
+        return StoreDevice.builder()
+                .store(store)
+                .device(device)
+                .count(count)
+                .price(price)
+                .dataCapacity(dataCapacity)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/entity/StoreLikes.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/entity/StoreLikes.java
@@ -1,0 +1,45 @@
+package com.TwoSeaU.BaData.domain.store.entity;
+
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+public class StoreLikes extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public static StoreLikes of(final Store store, final User user){
+
+        return StoreLikes.builder()
+                .store(store)
+                .user(user)
+                .build();
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/DeviceRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/DeviceRepository.java
@@ -1,0 +1,10 @@
+package com.TwoSeaU.BaData.domain.store.repository;
+
+import com.TwoSeaU.BaData.domain.store.entity.Device;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceRepository extends JpaRepository<Device,Long> {
+
+
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/ReStockRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/ReStockRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.store.repository;
+
+import com.TwoSeaU.BaData.domain.store.entity.ReStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReStockRepository extends JpaRepository<ReStock,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.store.repository;
+
+import com.TwoSeaU.BaData.domain.store.entity.StoreDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreDeviceRepository extends JpaRepository<StoreDevice,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreLikesRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreLikesRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.store.repository;
+
+import com.TwoSeaU.BaData.domain.store.entity.StoreLikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreLikesRepository extends JpaRepository<StoreLikes, Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreRepository.java
@@ -1,0 +1,9 @@
+package com.TwoSeaU.BaData.domain.store.repository;
+
+import com.TwoSeaU.BaData.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface StoreRepository extends JpaRepository<Store,Long> {
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/entity/CoinHistory.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/entity/CoinHistory.java
@@ -35,9 +35,9 @@ public class CoinHistory {
 	@Enumerated(EnumType.STRING)
 	private CoinSource coinSource;
 
-	private int amount;
+	private Integer amount;
 
-	public static CoinHistory of(final User user, final CoinSource coinSource, final int amount) {
+	public static CoinHistory of(final User user, final CoinSource coinSource, final Integer amount) {
 
 		return CoinHistory.builder()
 			.user(user)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,9 +11,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 10
 
   security:
     oauth2:


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #6 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 렌탈 관련 엔티티 생성
- [x] PostGis 세팅 위한 gradle 
- [x] yml 파일에 부족한 batch fetch size, open in view 설정   

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->

ERD 관련해서 변경된 부분입니다. 

ERD CLOUD 쪽지를 통해 명시해 놓았습니다.

- store 운영시간 varchar 대신 start_time, end_time 의 time형태로 전환
- Device에 있는 price를 삭제하고 Store_Device로 전환: 가맹점 별로 대여 가격을 다르게 할 수 있어서
- Device에 있는 데이터 용량을 삭제하고 Store_Device로 전환: 가맹점 별로 한달에 제공되는 GB를 다르게 제공할 수 있는 것 같아서 
- 대신 Device 별로 제공되는 최대 속도는 넣었는데 넣어 놓으면 좋을 것 같아요!
- 예약 테이블에 있는 수령 날짜 삭제 
- Category 대신 QuickReply 테이블로 바꾸고, 대신 중간 테이블은 review_quick_reply로 전환 
