### PR TITLE
Feat: [BADA-86] 사용자 데이터량 조회 API 구현

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/auth/service/SocialUserService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/auth/service/SocialUserService.java
@@ -42,6 +42,7 @@ public class SocialUserService {
                     getOAuth2UserProfileRequest.getNickName(),
                     socialType+getOAuth2UserProfileRequest.getId(),
                     null,
+                    150,
                     Role.GENERAL,
                     socialType,
                     getOAuth2UserProfileRequest.getEmail(),

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.TwoSeaU.BaData.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.TwoSeaU.BaData.domain.user.dto.response.DataResponse;
+
+import com.TwoSeaU.BaData.domain.user.service.UserService;
+import com.TwoSeaU.BaData.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping("/data")
+	public ResponseEntity<ApiResponse<DataResponse>> getData(@AuthenticationPrincipal User user) {
+		return ResponseEntity.ok().body(ApiResponse.success(userService.getData(user.getUsername())));
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/DataResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/DataResponse.java
@@ -1,0 +1,22 @@
+package com.TwoSeaU.BaData.domain.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class DataResponse {
+
+	private Integer dataAmount;
+
+	public static DataResponse of(final Integer dataAmount) {
+		return DataResponse.builder()
+			.dataAmount(dataAmount)
+			.build();
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/entity/User.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/entity/User.java
@@ -33,6 +33,8 @@ public class User {
 
     private String password;
 
+    private Integer dataAmount;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -46,6 +48,7 @@ public class User {
     public static User of(final String nickName,
                           final String userName,
                           final String password,
+                          final Integer dataAmount,
                           final Role role,
                           final SocialType socialType,
                           final String email,
@@ -55,6 +58,7 @@ public class User {
                 .nickName(nickName)
                 .username(userName)
                 .password(password)
+                .dataAmount(dataAmount)
                 .role(role)
                 .socialType(socialType)
                 .email(email)

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
@@ -1,0 +1,24 @@
+package com.TwoSeaU.BaData.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.TwoSeaU.BaData.domain.user.dto.response.DataResponse;
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import com.TwoSeaU.BaData.domain.user.exception.UserException;
+import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
+import com.TwoSeaU.BaData.global.response.GeneralException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+
+	public DataResponse getData(String username) {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+
+		return DataResponse.of(user.getDataAmount());
+	}
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #46 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 사용자 데이터량 조회 API 구현

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->
현재 User 회원가입 시 데이터량을 150으로 고정되게 하드코딩되어있습니다. 나중에 이 데이터량을 어떻게 해야할지 논의가 필요할 것같습니다.