### PR TITLE
Feat: [BADA-100] 신고 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Report.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Report.java
@@ -1,5 +1,6 @@
 package com.TwoSeaU.BaData.domain.trade.entity;
 
+import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
 import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -25,10 +26,14 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public static Report of(final Post post, final User user) {
+    @Enumerated(EnumType.STRING)
+    private ReportStatus reportStatus;
+
+    public static Report of(final Post post, final User user, final ReportStatus reportStatus) {
         return Report.builder()
                 .post(post)
                 .user(user)
+                .reportStatus(reportStatus)
                 .build();
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/enums/ReportStatus.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/enums/ReportStatus.java
@@ -1,0 +1,10 @@
+package com.TwoSeaU.BaData.domain.trade.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReportStatus {
+	QUESTION, ANSWER, COMPLETE
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/ReportRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/ReportRepository.java
@@ -1,8 +1,13 @@
 package com.TwoSeaU.BaData.domain.trade.repository;
 
+import java.util.List;
+
 import com.TwoSeaU.BaData.domain.trade.entity.Report;
+import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-
+	List<Report> findAllByUserIdAndReportStatus(Long userId, ReportStatus reportStatus);
+	List<Report> findAllByUserIdAndReportStatusNot(Long userId, ReportStatus reportStatus);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
@@ -3,6 +3,7 @@ package com.TwoSeaU.BaData.domain.trade.service;
 import com.TwoSeaU.BaData.domain.trade.dto.response.SaveReportResponse;
 import com.TwoSeaU.BaData.domain.trade.entity.Post;
 import com.TwoSeaU.BaData.domain.trade.entity.Report;
+import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
 import com.TwoSeaU.BaData.domain.trade.exception.TradeException;
 import com.TwoSeaU.BaData.domain.trade.repository.PostRepository;
 import com.TwoSeaU.BaData.domain.trade.repository.ReportRepository;
@@ -10,8 +11,7 @@ import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.domain.user.exception.UserException;
 import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
 import com.TwoSeaU.BaData.global.response.GeneralException;
-import jakarta.security.auth.message.AuthException;
-import jakarta.servlet.http.HttpSession;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +29,7 @@ public class ReportService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
 
-        Report savedReport = reportRepository.save(Report.of(post, user));
+        Report savedReport = reportRepository.save(Report.of(post, user, ReportStatus.QUESTION));
 
         return SaveReportResponse.of(savedReport.getId());
     }

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.TwoSeaU.BaData.domain.user.dto.response.CoinResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.DataResponse;
 
+import com.TwoSeaU.BaData.domain.user.dto.response.GetAllReportResponse;
 import com.TwoSeaU.BaData.domain.user.service.UserService;
 import com.TwoSeaU.BaData.global.response.ApiResponse;
 
@@ -29,5 +30,15 @@ public class UserController {
 	@GetMapping("/coin")
 	public ResponseEntity<ApiResponse<CoinResponse>> getCoin(@AuthenticationPrincipal User user) {
 		return ResponseEntity.ok().body(ApiResponse.success(userService.getCoin(user.getUsername())));
+	}
+
+	@GetMapping("/reports/complete")
+	public ResponseEntity<ApiResponse<GetAllReportResponse>> getCompleteReports(@AuthenticationPrincipal User user) {
+		return ResponseEntity.ok().body(ApiResponse.success(userService.getCompleteReports(user.getUsername())));
+	}
+
+	@GetMapping("/reports/pending")
+	public ResponseEntity<ApiResponse<GetAllReportResponse>> getPendingReports(@AuthenticationPrincipal User user) {
+		return ResponseEntity.ok().body(ApiResponse.success(userService.getPendingReports(user.getUsername())));
 	}
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetAllReportResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetAllReportResponse.java
@@ -1,0 +1,23 @@
+package com.TwoSeaU.BaData.domain.user.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetAllReportResponse {
+	private List<GetReportResponse> reportList;
+
+	public static GetAllReportResponse of(final List<GetReportResponse> reportList) {
+		return GetAllReportResponse.builder()
+			.reportList(reportList)
+			.build();
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetReportResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetReportResponse.java
@@ -1,0 +1,34 @@
+package com.TwoSeaU.BaData.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.TwoSeaU.BaData.domain.trade.entity.Report;
+import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetReportResponse {
+	private Long reportId;
+	private Long postId;
+	private ReportStatus reportStatus;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public static GetReportResponse from(final Report report) {
+		return GetReportResponse.builder()
+			.reportId(report.getId())
+			.postId(report.getPost().getId())
+			.reportStatus(report.getReportStatus())
+			.createdAt(report.getCreatedAt())
+			.updatedAt(report.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
@@ -1,9 +1,15 @@
 package com.TwoSeaU.BaData.domain.user.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
+import com.TwoSeaU.BaData.domain.trade.repository.ReportRepository;
 import com.TwoSeaU.BaData.domain.user.dto.response.CoinResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.DataResponse;
+import com.TwoSeaU.BaData.domain.user.dto.response.GetAllReportResponse;
+import com.TwoSeaU.BaData.domain.user.dto.response.GetReportResponse;
 import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.domain.user.exception.UserException;
 import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
@@ -15,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+	private final ReportRepository reportRepository;
 
 	public DataResponse getData(String username) {
 		User user = userRepository.findByUsername(username)
@@ -28,5 +35,29 @@ public class UserService {
 			 .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
 
 		return CoinResponse.of(user.getCoin());
+	}
+
+	public GetAllReportResponse getCompleteReports(String username) {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new GeneralException((UserException.USER_NOT_FOUND)));
+
+		List<GetReportResponse> CompleteReports = reportRepository.findAllByUserIdAndReportStatus(user.getId(), ReportStatus.COMPLETE)
+			.stream()
+			.map(GetReportResponse::from)
+			.toList();
+
+		return GetAllReportResponse.of(CompleteReports);
+	}
+
+	public GetAllReportResponse getPendingReports(String username) {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+
+		List<GetReportResponse> pendingReports = reportRepository.findAllByUserIdAndReportStatusNot(user.getId(), ReportStatus.COMPLETE)
+			.stream()
+			.map(GetReportResponse::from)
+			.toList();
+
+		return GetAllReportResponse.of(pendingReports);
 	}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #62 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 신고 상태가 COMPLETE인 모든 신고 내역 조회 API 구현
- [x] 신고 상태가 COMPLETE이 아닌 진행 중인 신고 내역 조회 API 구현

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->
- 신고가 처음 생성되면 ReportStatus가 QUESTION 상태로 저장됩니다.
- ERD에 Report 테이블에서 ReportStatus 라는 enum 컬럼이 추가되었습니다.
- 상태가 COMPLETE인 신고 내역만 조회 가능한 API와 상태가 COMPLETE이 아닌(아직 진행중인) 신고 내역만 조회 가능한 API로 설계했습니다.