### PR TITLE
Feat: [BADA-93] 게시글 등록 API

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/PostController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/PostController.java
@@ -1,17 +1,22 @@
 package com.TwoSeaU.BaData.domain.trade.controller;
 
+import com.TwoSeaU.BaData.domain.trade.dto.request.SaveDataPostRequest;
+import com.TwoSeaU.BaData.domain.trade.dto.request.SaveGifticonPostRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.response.PostsResponse;
+import com.TwoSeaU.BaData.domain.trade.dto.response.SavePostResponse;
 import com.TwoSeaU.BaData.domain.trade.dto.response.UserPostsResponse;
 import com.TwoSeaU.BaData.domain.trade.service.PostService;
 import com.TwoSeaU.BaData.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/trades")
-public class TradeController {
+public class PostController {
     private final PostService postService;
 
     @GetMapping("/posts")
@@ -31,5 +36,15 @@ public class TradeController {
     @GetMapping("/posts/deadline")
     public ResponseEntity<ApiResponse<PostsResponse>> getPostsByDeadLine() {
         return ResponseEntity.ok().body(ApiResponse.success(postService.getPostsByDeadLine()));
+    }
+
+    @PostMapping("/posts/gifticon")
+    public ResponseEntity<ApiResponse<SavePostResponse>> createGifticonPost(@RequestBody SaveGifticonPostRequest saveGifticonPostRequest, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok().body(ApiResponse.success(postService.createGifticonPost(saveGifticonPostRequest, user.getUsername())));
+    }
+
+    @PostMapping("/posts/data")
+    public ResponseEntity<ApiResponse<SavePostResponse>> createDataPost(@RequestBody SaveDataPostRequest saveDataPostRequest, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok().body(ApiResponse.success(postService.createDataPost(saveDataPostRequest, user.getUsername())));
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SaveDataPostRequest.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SaveDataPostRequest.java
@@ -1,0 +1,21 @@
+package com.TwoSeaU.BaData.domain.trade.dto.request;
+
+import com.TwoSeaU.BaData.domain.trade.enums.MobileCarrier;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SaveDataPostRequest {
+    private String title;
+    private MobileCarrier mobileCarrier;
+    private LocalDateTime deadLine;
+    private Integer capacity;
+    private Integer price;
+    private String commnent;
+    private MultipartFile file;
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SaveGifticonPostRequest.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SaveGifticonPostRequest.java
@@ -1,0 +1,23 @@
+package com.TwoSeaU.BaData.domain.trade.dto.request;
+
+import com.TwoSeaU.BaData.domain.trade.entity.GifticonCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SaveGifticonPostRequest {
+    private String title;
+    private String category;
+    private String partner;
+    private String couponNumber;
+    private LocalDateTime deadLine;
+    private LocalDateTime issueDate;
+    private Integer price;
+    private String comment;
+    private MultipartFile file;
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/SavePostResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/SavePostResponse.java
@@ -1,0 +1,17 @@
+package com.TwoSeaU.BaData.domain.trade.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SavePostResponse {
+    private Long postId;
+
+    public static SavePostResponse of(final Long postId) {
+        return SavePostResponse.builder()
+                .postId(postId)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Data.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Data.java
@@ -1,8 +1,10 @@
 package com.TwoSeaU.BaData.domain.trade.entity;
 
 import com.TwoSeaU.BaData.domain.trade.enums.MobileCarrier;
+import com.TwoSeaU.BaData.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -18,11 +20,11 @@ public class Data extends Post {
 
     private Integer capacity;
 
-    public static Data of(final MobileCarrier mobileCarrier, final Integer capacity) {
-
-        return Data.builder()
-                .mobileCarrier(mobileCarrier)
-                .capacity(capacity)
-                .build();
+    public Data(User user, String title, String comment, Integer price,
+                LocalDateTime deadLine, String postImage, Boolean isSold,
+                MobileCarrier mobileCarrier, Integer capacity) {
+        super(user, title, comment, price, deadLine, postImage, isSold);
+        this.mobileCarrier = mobileCarrier;
+        this.capacity = capacity;
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Gifticon.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Gifticon.java
@@ -1,6 +1,6 @@
 package com.TwoSeaU.BaData.domain.trade.entity;
 
-import com.TwoSeaU.BaData.global.common.BaseEntity;
+import com.TwoSeaU.BaData.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,14 +24,13 @@ public class Gifticon extends Post{
     @JoinColumn(name = "category_id", nullable = false)
     private GifticonCategory category;
 
-    public static Gifticon of(final LocalDateTime issueDate, final String couponNumber,
-                              final String partner, final GifticonCategory category) {
-
-        return Gifticon.builder()
-                .issueDate(issueDate)
-                .couponNumber(couponNumber)
-                .partner(partner)
-                .category(category)
-                .build();
+    public Gifticon(User user, String title, String comment, Integer price,
+                LocalDateTime deadLine, String postImage, Boolean isSold,
+                    LocalDateTime issueDate, String couponNumber, String partner, GifticonCategory category) {
+        super(user, title, comment, price, deadLine, postImage, isSold);
+        this.issueDate = issueDate;
+        this.couponNumber = couponNumber;
+        this.partner = partner;
+        this.category = category;
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Post.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Post.java
@@ -35,4 +35,14 @@ public abstract class Post extends BaseEntity {
     private String postImage;
 
     private Boolean isSold;
+
+    public Post(User seller, String title, String comment, Integer price, LocalDateTime deadLine, String postImage, Boolean isSold) {
+        this.seller = seller;
+        this.title = title;
+        this.comment = comment;
+        this.price = price;
+        this.deadLine = deadLine;
+        this.postImage = postImage;
+        this.isSold = isSold;
+    }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
@@ -23,7 +23,8 @@ public enum TradeException implements BaseException {
     OCR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3011, "OCR 처리에 실패했습니다."),
     EXPIRED_POST_ACCESS(HttpStatus.BAD_REQUEST, 3012, "이미 마감 기한이 지난 게시글입니다."),
     EXPIRED_POST_MODIFY(HttpStatus.BAD_REQUEST, 3013, "마감 기한이 지난 게시글은 수정할 수 없습니다."),
-    NOT_LIKED_POST(HttpStatus.BAD_REQUEST, 3014, "찜한 적 없는 게시글입니다.");
+    NOT_LIKED_POST(HttpStatus.BAD_REQUEST, 3014, "찜한 적 없는 게시글입니다."),
+    NOT_FOUND_GIFTICON_CATEGORY(HttpStatus.NOT_FOUND, 3015, "찾을 수 없는 카테고리입니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/GifticonCategoryRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/GifticonCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.TwoSeaU.BaData.domain.trade.repository;
+
+import com.TwoSeaU.BaData.domain.trade.entity.GifticonCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GifticonCategoryRepository extends JpaRepository<GifticonCategory, Long> {
+    Optional<GifticonCategory> findByCategoryName(String categoryName);
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PostService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PostService.java
@@ -1,9 +1,23 @@
 package com.TwoSeaU.BaData.domain.trade.service;
 
+import com.TwoSeaU.BaData.domain.trade.dto.request.SaveDataPostRequest;
+import com.TwoSeaU.BaData.domain.trade.dto.request.SaveGifticonPostRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.response.PostResponse;
 import com.TwoSeaU.BaData.domain.trade.dto.response.PostsResponse;
+import com.TwoSeaU.BaData.domain.trade.dto.response.SavePostResponse;
 import com.TwoSeaU.BaData.domain.trade.dto.response.UserPostsResponse;
+import com.TwoSeaU.BaData.domain.trade.entity.Data;
+import com.TwoSeaU.BaData.domain.trade.entity.Gifticon;
+import com.TwoSeaU.BaData.domain.trade.entity.GifticonCategory;
+import com.TwoSeaU.BaData.domain.trade.exception.TradeException;
+import com.TwoSeaU.BaData.domain.trade.repository.DataRepository;
+import com.TwoSeaU.BaData.domain.trade.repository.GifticonCategoryRepository;
+import com.TwoSeaU.BaData.domain.trade.repository.GifticonRepository;
 import com.TwoSeaU.BaData.domain.trade.repository.PostRepository;
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import com.TwoSeaU.BaData.domain.user.exception.UserException;
+import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
+import com.TwoSeaU.BaData.global.response.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
@@ -13,6 +27,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final GifticonRepository gifticonRepository;
+    private final DataRepository dataRepository;
+    private final UserRepository userRepository;
+    private final GifticonCategoryRepository gifticonCategoryRepository;
 
     public PostsResponse findAllPosts() {
         List<PostResponse> allPosts = postRepository.findByIsSoldOrderByCreatedAtDesc(false)
@@ -61,6 +79,58 @@ public class PostService {
 
         return PostsResponse.builder()
                 .postsResponse(allPosts)
+                .build();
+    }
+
+    public SavePostResponse createGifticonPost(SaveGifticonPostRequest saveGifticonPostRequest, String username) {
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+        GifticonCategory category = gifticonCategoryRepository.findByCategoryName(saveGifticonPostRequest.getCategory())
+                .orElseThrow(() -> new GeneralException(TradeException.NOT_FOUND_GIFTICON_CATEGORY));
+
+        Gifticon gifticon = new Gifticon(
+                user,
+                saveGifticonPostRequest.getTitle(),
+                saveGifticonPostRequest.getComment(),
+                saveGifticonPostRequest.getPrice(),
+                saveGifticonPostRequest.getDeadLine(),
+                "no image",
+                false,
+                saveGifticonPostRequest.getIssueDate(),
+                saveGifticonPostRequest.getCouponNumber(),
+                saveGifticonPostRequest.getPartner(),
+                category
+        );
+
+        Gifticon savedGifticon = gifticonRepository.save(gifticon);
+
+        return SavePostResponse.builder()
+                .postId(savedGifticon.getId())
+                .build();
+    }
+
+    public SavePostResponse createDataPost(SaveDataPostRequest saveDataPostRequest, String username) {
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+
+        Data data = new Data(
+                user,
+                saveDataPostRequest.getTitle(),
+                null,
+                saveDataPostRequest.getPrice(),
+                saveDataPostRequest.getDeadLine(),
+                "no image",
+                false,
+                saveDataPostRequest.getMobileCarrier(),
+                saveDataPostRequest.getCapacity()
+        );
+
+        Data savedData = dataRepository.save(data);
+
+        return SavePostResponse.builder()
+                .postId(savedData.getId())
                 .build();
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #50 
### 🚀 작업 내용
- [x] 1차 MVP 기프티콘 게시글 등록 API 개발
- [x] 1차 MVP 데이터 게시글 등록 API 개발

### 🔍 리뷰 요청 사항
빠른 개발을 위해 먼저 저장 로직만 구현했습니다.
따라서 ELA 기능과 S3 저장 로직은 2차 스프린트, 혹은 1차 개발을 일찍 마칠 시 개발 예정인 점 참고 부탁드립니다.
또한 BaseEntity로 인해 @SuperBuilder 어노테이션 사용이 불가능해 불가피하게 Post, Gifticon, Data Entity는 생성자를 사용했습니다.