### PR TITLE
Feat: [BADA-108] 사용자 구매 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Payment.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Payment.java
@@ -7,10 +7,12 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PaymentRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PaymentRepository.java
@@ -1,0 +1,11 @@
+package com.TwoSeaU.BaData.domain.trade.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.TwoSeaU.BaData.domain.trade.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+	List<Payment> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 
 public interface PostLikesRepository extends JpaRepository<PostLikes, Long> {
     Optional<PostLikes> findByUserIdAndPostId(Long userId, Long postId);
+    Long countByPostId(Long postId);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.TwoSeaU.BaData.domain.user.dto.response.CoinResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.DataResponse;
 
+import com.TwoSeaU.BaData.domain.user.dto.response.GetAllPurchasesResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetAllReportResponse;
 import com.TwoSeaU.BaData.domain.user.service.UserService;
 import com.TwoSeaU.BaData.global.response.ApiResponse;
@@ -40,5 +41,10 @@ public class UserController {
 	@GetMapping("/reports/pending")
 	public ResponseEntity<ApiResponse<GetAllReportResponse>> getPendingReports(@AuthenticationPrincipal User user) {
 		return ResponseEntity.ok().body(ApiResponse.success(userService.getPendingReports(user.getUsername())));
+	}
+
+	@GetMapping("/purchases")
+	public ResponseEntity<ApiResponse<GetAllPurchasesResponse>> getAllPurchases(@AuthenticationPrincipal User user) {
+		return ResponseEntity.ok().body(ApiResponse.success(userService.getAllPurchasesResponse(user.getUsername())));
 	}
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetAllPurchasesResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetAllPurchasesResponse.java
@@ -1,0 +1,24 @@
+package com.TwoSeaU.BaData.domain.user.dto.response;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetAllPurchasesResponse {
+
+	private List<GetPurchaseResponse> purchaseResponseList;
+
+	public static GetAllPurchasesResponse of(List<GetPurchaseResponse> purchaseResponseList) {
+		return GetAllPurchasesResponse.builder()
+			.purchaseResponseList(purchaseResponseList)
+			.build();
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetPurchaseResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetPurchaseResponse.java
@@ -1,0 +1,42 @@
+package com.TwoSeaU.BaData.domain.user.dto.response;
+
+import com.TwoSeaU.BaData.domain.trade.entity.Gifticon;
+import com.TwoSeaU.BaData.domain.trade.entity.Payment;
+import com.TwoSeaU.BaData.domain.trade.entity.Post;
+import com.TwoSeaU.BaData.domain.trade.enums.PostCategory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetPurchaseResponse {
+	private Long paymentId;
+	private Long postId;
+	private PostCategory postCategory;
+	private String partner;
+	private String title;
+	private Integer price;
+	private Long postLikes;
+	private String postImage;
+	private Boolean isSold;
+
+	public static GetPurchaseResponse from(final Post post, final Payment payment, final Long postLikes) {
+		return GetPurchaseResponse.builder()
+			.paymentId(payment.getId())
+			.postId(post.getId())
+			.postCategory(post instanceof Gifticon ? PostCategory.GIFTICON : PostCategory.DATA)
+			.partner(post instanceof Gifticon gifticon ? gifticon.getPartner() : null)
+			.title(post.getTitle())
+			.price(post.getPrice())
+			.postLikes(postLikes)
+			.postImage(post.getPostImage())
+			.isSold(post.getIsSold())
+			.build();
+	}
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #73 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 사용자 구매 내역 조회 API 구현

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->
- API 조회 시 결제ID, 게시글ID, 게시글카테고리, 제휴사, 제목, 가격, 찜 수, 이미지, 판매 여부 를 return값으로 설정했습니다. 추가하거나 불필요한 부분이 있는지 확인 부탁드립니다.