### PR TITLE
Feat: [BADA-109] 유저 거래글 조회 시 찜 수와 등록 여부 확인 기능

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/PostController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/PostController.java
@@ -20,22 +20,23 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/posts")
-    public ResponseEntity<ApiResponse<PostsResponse>> getPosts(@RequestParam(required = false) String query) {
+    public ResponseEntity<ApiResponse<PostsResponse>> getPosts(
+            @RequestParam(required = false) String query, @AuthenticationPrincipal User user) {
         if (query != null && !query.isEmpty()) {
-            return ResponseEntity.ok().body(ApiResponse.success(postService.searchPosts(query)));
+            return ResponseEntity.ok().body(ApiResponse.success(postService.searchPosts(query, user)));
         }
 
-        return ResponseEntity.ok().body(ApiResponse.success(postService.findAllPosts()));
+        return ResponseEntity.ok().body(ApiResponse.success(postService.findAllPosts(user)));
     }
 
     @GetMapping("/posts/{userId}")
-    public ResponseEntity<ApiResponse<UserPostsResponse>> getPostsByUserId(@PathVariable Long userId) {
-        return ResponseEntity.ok().body(ApiResponse.success(postService.getPostsByUserId(userId)));
+    public ResponseEntity<ApiResponse<UserPostsResponse>> getPostsByUserId(@PathVariable Long userId, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok().body(ApiResponse.success(postService.getPostsByUserId(userId, user)));
     }
 
     @GetMapping("/posts/deadline")
-    public ResponseEntity<ApiResponse<PostsResponse>> getPostsByDeadLine() {
-        return ResponseEntity.ok().body(ApiResponse.success(postService.getPostsByDeadLine()));
+    public ResponseEntity<ApiResponse<PostsResponse>> getPostsByDeadLine(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok().body(ApiResponse.success(postService.getPostsByDeadLine(user)));
     }
 
     @PostMapping("/posts/gifticon")

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/PostResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/PostResponse.java
@@ -19,16 +19,23 @@ public class PostResponse {
     private LocalDateTime createdAt;
     private String postImage;
     private PostCategory postCategory;
+    private String gifticonCategory;
+    private Integer likesCount;
+    private Boolean isLiked;
 
-    public static PostResponse from(final Post post) {
+    public static PostResponse from(final Post post, final Integer likesCount, final Boolean isLiked) {
+
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
+                .partner(post instanceof Gifticon gifticon ? gifticon.getPartner() : null)
                 .price(post.getPrice())
                 .createdAt(post.getCreatedAt())
                 .postImage(post.getPostImage())
                 .postCategory(post instanceof Gifticon ? PostCategory.GIFTICON : PostCategory.DATA)
-                .partner(post instanceof Gifticon gifticon ? gifticon.getPartner() : null)
+                .gifticonCategory(post instanceof Gifticon gifticon ? gifticon.getCategory().getCategoryName() : null)
+                .likesCount(likesCount)
+                .isLiked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/UserPostsResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/UserPostsResponse.java
@@ -2,17 +2,16 @@ package com.TwoSeaU.BaData.domain.trade.dto.response;
 
 import lombok.*;
 
-import java.util.List;
-
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserPostsResponse {
-    private List<PostResponse> soldingPostsResponse;
-    private List<PostResponse> soldedPostsResponse;
+    private PostsResponse soldingPostsResponse;
+    private PostsResponse soldedPostsResponse;
 
-    public static UserPostsResponse of(final List<PostResponse> soldingPosts, final List<PostResponse> soldedPosts) {
+    public static UserPostsResponse of(final PostsResponse soldingPosts, final PostsResponse soldedPosts) {
+
         return UserPostsResponse.builder()
                 .soldingPostsResponse(soldingPosts)
                 .soldedPostsResponse(soldedPosts)

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Gifticon.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Gifticon.java
@@ -20,7 +20,7 @@ public class Gifticon extends Post{
 
     private String partner;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "category_id", nullable = false)
     private GifticonCategory category;
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/GifticonCategory.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/GifticonCategory.java
@@ -2,12 +2,10 @@ package com.TwoSeaU.BaData.domain.trade.entity;
 
 import com.TwoSeaU.BaData.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesRepository.java
@@ -6,5 +6,6 @@ import java.util.Optional;
 
 public interface PostLikesRepository extends JpaRepository<PostLikes, Long> {
     Optional<PostLikes> findByUserIdAndPostId(Long userId, Long postId);
-    Long countByPostId(Long postId);
+    Boolean existsByUserIdAndPostId(Long userId, Long postId);
+    int countByPostId(Long postId);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetLikesPostResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetLikesPostResponse.java
@@ -20,11 +20,11 @@ public class GetLikesPostResponse {
 	private String partner;
 	private String title;
 	private Integer price;
-	private Long postLikes;
+	private int postLikes;
 	private String postImage;
 	private Boolean isSold;
 
-	public static GetLikesPostResponse from(final Post post, final Long postLikes) {
+	public static GetLikesPostResponse from(final Post post, final int postLikes) {
 		return GetLikesPostResponse.builder()
 			.postId(post.getId())
 			.postCategory(post instanceof Gifticon ? PostCategory.GIFTICON : PostCategory.DATA)

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetPurchaseResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetPurchaseResponse.java
@@ -22,11 +22,11 @@ public class GetPurchaseResponse {
 	private String partner;
 	private String title;
 	private Integer price;
-	private Long postLikes;
+	private int postLikes;
 	private String postImage;
 	private Boolean isSold;
 
-	public static GetPurchaseResponse from(final Post post, final Payment payment, final Long postLikes) {
+	public static GetPurchaseResponse from(final Post post, final Payment payment, final int postLikes) {
 		return GetPurchaseResponse.builder()
 			.paymentId(payment.getId())
 			.postId(post.getId())

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
 			.map(payment -> {
 				Post post = postRepository.findById(payment.getPost().getId())
 					.orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
-				Long postLikes = postLikesRepository.countByPostId(post.getId());
+				int postLikes = postLikesRepository.countByPostId(post.getId());
 
 				return GetPurchaseResponse.from(post, payment, postLikes);
 			})

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
@@ -103,7 +103,7 @@ public class UserService {
 			.map(postLikes -> {
 				Post post = postRepository.findById(postLikes.getPost().getId())
 					.orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
-				Long postLikesCount = postLikesRepository.countByPostId(post.getId());
+				int postLikesCount = postLikesRepository.countByPostId(post.getId());
 
 				return GetLikesPostResponse.from(post, postLikesCount);
 			})


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #74 

### 🚀 작업 내용
- [x] 동일 로직 하나의 메소드로 분리 등 리펙토링
- [x] 게시글의 찜 개수 response 추가
- [x] 게시글의 자신의 찜 등록 여부 response 추가
- [x] 기프티콘 카테고리 response에 추가

### 🔍 리뷰 요청 사항
Service 단을 중점적으로 확인 부탁드립니다.