### PR TITLE
Feat: [BADA-114] 게시글 상세 조회 API

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/PostController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/PostController.java
@@ -2,9 +2,7 @@ package com.TwoSeaU.BaData.domain.trade.controller;
 
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveDataPostRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveGifticonPostRequest;
-import com.TwoSeaU.BaData.domain.trade.dto.response.PostsResponse;
-import com.TwoSeaU.BaData.domain.trade.dto.response.SavePostResponse;
-import com.TwoSeaU.BaData.domain.trade.dto.response.UserPostsResponse;
+import com.TwoSeaU.BaData.domain.trade.dto.response.*;
 import com.TwoSeaU.BaData.domain.trade.service.PostService;
 import com.TwoSeaU.BaData.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +35,11 @@ public class PostController {
     @GetMapping("/posts/deadline")
     public ResponseEntity<ApiResponse<PostsResponse>> getPostsByDeadLine(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok().body(ApiResponse.success(postService.getPostsByDeadLine(user)));
+    }
+
+    @GetMapping("{postId}/post")
+    public ResponseEntity<ApiResponse<GetPostDetailResponse>> getPostDetail(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok().body(ApiResponse.success(postService.getPost(postId, user)));
     }
 
     @PostMapping("/posts/gifticon")

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetDataDetailResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetDataDetailResponse.java
@@ -1,0 +1,42 @@
+package com.TwoSeaU.BaData.domain.trade.dto.response;
+
+import com.TwoSeaU.BaData.domain.trade.entity.Data;
+import com.TwoSeaU.BaData.domain.trade.enums.MobileCarrier;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetDataDetailResponse {
+    private Long id;
+    private String title;
+    private String comment;
+    private Integer price;
+    private LocalDateTime deadLine;
+    private String postImage;
+    private Boolean isSold;
+    private LocalDateTime createdAt;
+    private MobileCarrier mobileCarrier;
+    private Integer capacity;
+    private Integer likesCount;
+    private Boolean isLiked;
+
+    public static GetDataDetailResponse from(final Data data, final Integer likesCount, final Boolean isLiked) {
+        return GetDataDetailResponse.builder()
+                .id(data.getId())
+                .title(data.getTitle())
+                .comment(data.getComment())
+                .price(data.getPrice())
+                .deadLine(data.getDeadLine())
+                .postImage(data.getPostImage())
+                .isSold(data.getIsSold())
+                .createdAt(data.getCreatedAt())
+                .mobileCarrier(data.getMobileCarrier())
+                .capacity(data.getCapacity())
+                .likesCount(likesCount)
+                .isLiked(isLiked)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetGifticonDetailResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetGifticonDetailResponse.java
@@ -1,0 +1,42 @@
+package com.TwoSeaU.BaData.domain.trade.dto.response;
+
+import com.TwoSeaU.BaData.domain.trade.entity.Gifticon;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetGifticonDetailResponse {
+    private Long id;
+    private String title;
+    private String comment;
+    private Integer price;
+    private LocalDateTime deadLine;
+    private String postImage;
+    private Boolean isSold;
+    private LocalDateTime createdAt;
+    private LocalDateTime issueDate;
+    private String partner;
+    private Integer likesCount;
+    private Boolean isLiked;
+
+    public static GetGifticonDetailResponse from(final Gifticon gifticon, final Integer likesCount, final Boolean isLiked) {
+        return GetGifticonDetailResponse.builder()
+                .id(gifticon.getId())
+                .title(gifticon.getTitle())
+                .comment(gifticon.getComment())
+                .price(gifticon.getPrice())
+                .deadLine(gifticon.getDeadLine())
+                .postImage(gifticon.getPostImage())
+                .isSold(gifticon.getIsSold())
+                .createdAt(gifticon.getCreatedAt())
+                .issueDate(gifticon.getIssueDate())
+                .partner(gifticon.getPartner())
+                .likesCount(likesCount)
+                .isLiked(isLiked)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetPostDetailResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetPostDetailResponse.java
@@ -1,0 +1,19 @@
+package com.TwoSeaU.BaData.domain.trade.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetPostDetailResponse<T> {
+    private GetSellerResponse seller;
+    private T post;
+
+    public static GetPostDetailResponse of(final GetSellerResponse seller, final Object post) {
+        return GetPostDetailResponse.builder()
+                .seller(seller)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetSellerResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetSellerResponse.java
@@ -14,7 +14,7 @@ public class GetSellerResponse {
     public static GetSellerResponse from(final User user) {
         return GetSellerResponse.builder()
                 .userId(user.getId())
-                .username(user.getUsername())
+                .username(user.getNickName())
                 .build();
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetSellerResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/response/GetSellerResponse.java
@@ -1,0 +1,20 @@
+package com.TwoSeaU.BaData.domain.trade.dto.response;
+
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetSellerResponse {
+    private Long userId;
+    private String username;
+
+    public static GetSellerResponse from(final User user) {
+        return GetSellerResponse.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .build();
+    }
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PostService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PostService.java
@@ -2,10 +2,7 @@ package com.TwoSeaU.BaData.domain.trade.service;
 
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveDataPostRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveGifticonPostRequest;
-import com.TwoSeaU.BaData.domain.trade.dto.response.PostResponse;
-import com.TwoSeaU.BaData.domain.trade.dto.response.PostsResponse;
-import com.TwoSeaU.BaData.domain.trade.dto.response.SavePostResponse;
-import com.TwoSeaU.BaData.domain.trade.dto.response.UserPostsResponse;
+import com.TwoSeaU.BaData.domain.trade.dto.response.*;
 import com.TwoSeaU.BaData.domain.trade.entity.Data;
 import com.TwoSeaU.BaData.domain.trade.entity.Gifticon;
 import com.TwoSeaU.BaData.domain.trade.entity.GifticonCategory;
@@ -132,5 +129,35 @@ public class PostService {
         return SavePostResponse.builder()
                 .postId(savedData.getId())
                 .build();
+    }
+
+    public GetPostDetailResponse getPost(Long postId, UserDetails user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
+
+        GetSellerResponse seller = GetSellerResponse.from(post.getSeller());
+
+        int likesCount = postLikesRepository.countByPostId(postId);
+        boolean isLiked = false;
+
+        if(user != null) {
+            User loginUser = userRepository.findByUsername(user.getUsername())
+                    .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+            isLiked = postLikesRepository.existsByUserIdAndPostId(loginUser.getId(), postId);
+        }
+
+        if (post instanceof Gifticon) {
+            GetGifticonDetailResponse getGifticonDetailResponse =
+                    GetGifticonDetailResponse.from((Gifticon) post, likesCount, isLiked);
+            return GetPostDetailResponse.of(seller, getGifticonDetailResponse);
+        }
+        else if (post instanceof Data) {
+            GetDataDetailResponse getDataDetailResponse =
+                    GetDataDetailResponse.from((Data) post, likesCount, isLiked);
+            return GetPostDetailResponse.of(seller, getDataDetailResponse);
+        }
+        else {
+            throw new GeneralException(TradeException.POST_NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> close: #80 

### 🚀 작업 내용

- [x] 기프티콘 게시글 상세조회 API 개발
- [x] 데이터 게시글 상세조회 API 개발

### 🔍 리뷰 요청 사항
현 구조는 SellerResponse와 GifticonDetailResponse 또는 DataDetailResponse를 합친 PostDetailResponse를 return하는 구조입니다.
Response 관련하여 개선이 필요하지는 않을지 중점으로 리뷰해주시면 감사하겠습니다.