### PR TITLE
Feat: [BADA-127] 재입고 알림 저장 API 

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/controller/RestockController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/controller/RestockController.java
@@ -1,0 +1,31 @@
+package com.TwoSeaU.BaData.domain.rental.controller;
+
+import com.TwoSeaU.BaData.domain.rental.dto.request.RestockDeviceRequest;
+import com.TwoSeaU.BaData.domain.rental.service.RestockService;
+import com.TwoSeaU.BaData.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/restock")
+public class RestockController {
+
+    private final RestockService restockService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Long>> restockStoreDevice(@RequestBody @Valid RestockDeviceRequest restockDeviceRequest,
+                                                                @AuthenticationPrincipal User user){
+
+        return ResponseEntity.ok(ApiResponse.success(restockService.restockStoreDevice(restockDeviceRequest, user.getUsername())));
+    }
+
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/dto/request/RestockDeviceRequest.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/dto/request/RestockDeviceRequest.java
@@ -1,0 +1,26 @@
+package com.TwoSeaU.BaData.domain.rental.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestockDeviceRequest {
+
+    @NotNull(message = "storeDeviceId는 필수입니다.")
+    private Long storeDeviceId;
+
+    @NotNull(message = "예약할 수량은 필수입니다.")
+    @Min(value = 1, message = "최소 1개 이상 예약해야 합니다.")
+    private Integer count;
+
+    @NotNull(message = "대여 시작일은 필수입니다.")
+    private LocalDateTime desiredStartDate;
+
+    @NotNull(message = "대여 종료일은 필수입니다.")
+    private LocalDateTime desiredEndDate;
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/ReStock.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/ReStock.java
@@ -1,8 +1,10 @@
 package com.TwoSeaU.BaData.domain.rental.entity;
 
+import com.TwoSeaU.BaData.domain.rental.exception.RentalException;
 import com.TwoSeaU.BaData.domain.store.entity.StoreDevice;
 import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.global.common.BaseEntity;
+import com.TwoSeaU.BaData.global.response.GeneralException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -45,6 +47,10 @@ public class ReStock extends BaseEntity {
 
     public static ReStock of(final StoreDevice storeDevice, final User user,
                              final LocalDateTime desiredStartDate, final LocalDateTime desiredEndDate){
+
+        if (desiredStartDate.isAfter(desiredEndDate)) {
+            throw new GeneralException(RentalException.CANT_END_DATE_BEFORE_THAN_START_DATE);
+        }
 
         return ReStock.builder()
                 .user(user)

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/ReStock.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/ReStock.java
@@ -1,7 +1,9 @@
-package com.TwoSeaU.BaData.domain.store.entity;
+package com.TwoSeaU.BaData.domain.rental.entity;
 
+import com.TwoSeaU.BaData.domain.store.entity.StoreDevice;
 import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.global.common.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,11 +37,20 @@ public class ReStock extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public ReStock of(final StoreDevice storeDevice, final User user){
+    @Column(nullable = false)
+    private LocalDateTime desiredStartDate;
+
+    @Column(nullable = false)
+    private LocalDateTime desiredEndDate;
+
+    public static ReStock of(final StoreDevice storeDevice, final User user,
+                             final LocalDateTime desiredStartDate, final LocalDateTime desiredEndDate){
 
         return ReStock.builder()
                 .user(user)
                 .storeDevice(storeDevice)
+                .desiredStartDate(desiredStartDate)
+                .desiredEndDate(desiredEndDate)
                 .build();
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Reservation.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Reservation.java
@@ -1,8 +1,10 @@
 package com.TwoSeaU.BaData.domain.rental.entity;
 
 import com.TwoSeaU.BaData.domain.rental.enums.ReservationStatus;
+import com.TwoSeaU.BaData.domain.rental.exception.RentalException;
 import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.global.common.BaseEntity;
+import com.TwoSeaU.BaData.global.response.GeneralException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -45,6 +47,10 @@ public class Reservation extends BaseEntity {
     private ReservationStatus status;
 
     public static Reservation of(final User user, final LocalDateTime rentalStartDate, final LocalDateTime rentalEndDate){
+
+        if (rentalStartDate.isAfter(rentalEndDate)) {
+            throw new GeneralException(RentalException.CANT_END_DATE_BEFORE_THAN_START_DATE);
+        }
 
         return Reservation.builder()
                 .user(user)

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/exception/RentalException.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/exception/RentalException.java
@@ -12,7 +12,10 @@ public enum RentalException implements BaseException {
     ALREADY_RENTAL_EXIST_SAME_PERIOD(HttpStatus.BAD_REQUEST, 4002, "이미 해당 기간에 예약이 존재합니다."),
     RESERVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, 4003, "해당 예약을 찾을 수 없습니다."),
     CANT_CANCEL_ALREADY_RENTAL(HttpStatus.BAD_REQUEST, 4004, "이미 빌리거나 이미 사용한 경우 예약을 취소할 수 없습니다."),
-    CANT_CANCEL_RESERVED_USERS(HttpStatus.BAD_REQUEST, 4005, "예약을 진행한 당사자만 예약을 취소할 수 있습니다.");
+    CANT_CANCEL_RESERVED_USERS(HttpStatus.BAD_REQUEST, 4005, "예약을 진행한 당사자만 예약을 취소할 수 있습니다."),
+    CANT_RESTOCK_WHEN_AVAILABLE_COUNT(HttpStatus.BAD_REQUEST, 4006, "예약 가능한 상황일 때는 재입고를 신청할 수 없습니다"),
+    CANT_RESERVE_MORE_THAN_COUNT(HttpStatus.BAD_REQUEST, 4007, "예약 가능 대수는 가맹점이 소유한 기기 이상으로 할 수 없습니다"),
+    CANT_RESTOCK_MORE_THAN_COUNT(HttpStatus.BAD_REQUEST, 4008, "재입고 알림 대수는 가맹점이 소유한 기기 이상으로 할 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/exception/RentalException.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/exception/RentalException.java
@@ -14,8 +14,8 @@ public enum RentalException implements BaseException {
     CANT_CANCEL_ALREADY_RENTAL(HttpStatus.BAD_REQUEST, 4004, "이미 빌리거나 이미 사용한 경우 예약을 취소할 수 없습니다."),
     CANT_CANCEL_RESERVED_USERS(HttpStatus.BAD_REQUEST, 4005, "예약을 진행한 당사자만 예약을 취소할 수 있습니다."),
     CANT_RESTOCK_WHEN_AVAILABLE_COUNT(HttpStatus.BAD_REQUEST, 4006, "예약 가능한 상황일 때는 재입고를 신청할 수 없습니다"),
-    CANT_RESERVE_MORE_THAN_COUNT(HttpStatus.BAD_REQUEST, 4007, "예약 가능 대수는 가맹점이 소유한 기기 이상으로 할 수 없습니다"),
-    CANT_RESTOCK_MORE_THAN_COUNT(HttpStatus.BAD_REQUEST, 4008, "재입고 알림 대수는 가맹점이 소유한 기기 이상으로 할 수 없습니다");
+    CANT_RESTOCK_MORE_THAN_COUNT(HttpStatus.BAD_REQUEST, 4007, "재입고 알림 대수는 가맹점이 소유한 기기 이상으로 할 수 없습니다"),
+    CANT_END_DATE_BEFORE_THAN_START_DATE(HttpStatus.BAD_REQUEST, 4008, "예약 재입고 시 시작 날짜는 종료 날짜보다 먼저 와야 합니다");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReStockRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReStockRepository.java
@@ -1,6 +1,6 @@
-package com.TwoSeaU.BaData.domain.store.repository;
+package com.TwoSeaU.BaData.domain.rental.repository;
 
-import com.TwoSeaU.BaData.domain.store.entity.ReStock;
+import com.TwoSeaU.BaData.domain.rental.entity.ReStock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReStockRepository extends JpaRepository<ReStock,Long> {

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/service/RestockService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/service/RestockService.java
@@ -1,0 +1,68 @@
+package com.TwoSeaU.BaData.domain.rental.service;
+
+import com.TwoSeaU.BaData.domain.rental.dto.request.RestockDeviceRequest;
+import com.TwoSeaU.BaData.domain.rental.entity.ReStock;
+import com.TwoSeaU.BaData.domain.rental.exception.RentalException;
+import com.TwoSeaU.BaData.domain.rental.repository.DeviceReservationRepository;
+import com.TwoSeaU.BaData.domain.rental.repository.ReStockRepository;
+import com.TwoSeaU.BaData.domain.store.entity.StoreDevice;
+import com.TwoSeaU.BaData.domain.store.exception.StoreException;
+import com.TwoSeaU.BaData.domain.store.repository.StoreDeviceRepository;
+import com.TwoSeaU.BaData.domain.user.entity.User;
+import com.TwoSeaU.BaData.domain.user.exception.UserException;
+import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
+import com.TwoSeaU.BaData.global.response.GeneralException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RestockService {
+
+    private final ReStockRepository reStockRepository;
+    private final StoreDeviceRepository storeDeviceRepository;
+    private final DeviceReservationRepository deviceReservationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long restockStoreDevice(final RestockDeviceRequest restockDeviceRequest, final String username){
+
+        final StoreDevice storeDevice = storeDeviceRepository.findById(restockDeviceRequest.getStoreDeviceId())
+                .orElseThrow(()-> new GeneralException(StoreException.CANT_FIND_STORE_DEVICE));
+
+        validateRestock(restockDeviceRequest, storeDevice);
+
+        final User user = userRepository.findByUsername(username).orElseThrow(()->new GeneralException(
+                UserException.USER_NOT_FOUND));
+
+        final ReStock reStock = reStockRepository.save(
+                ReStock.of(storeDevice, user, restockDeviceRequest.getDesiredStartDate(), restockDeviceRequest.getDesiredEndDate()));
+
+        return reStock.getId();
+    }
+
+
+    // 해당 기간에 예약 가능하다면 예외 처리
+    private void validateRestock(final RestockDeviceRequest restockDeviceRequest, final StoreDevice storeDevice){
+
+        // 재입고 알림 요청 댓수가 가맹점이 소유한 기기보다 더 많다면
+        if(storeDevice.getCount()<restockDeviceRequest.getCount()){
+            throw new GeneralException(RentalException.CANT_RESTOCK_MORE_THAN_COUNT);
+        }
+
+        final Long availableCount = deviceReservationRepository.findAvailableCountsByStoreDeviceIdAndPeriod(
+                restockDeviceRequest.getStoreDeviceId(),
+                restockDeviceRequest.getDesiredStartDate(),
+                restockDeviceRequest.getDesiredEndDate()).orElseThrow(()-> new GeneralException(
+                StoreException.CANT_FIND_STORE_DEVICE));
+
+        if(availableCount >= restockDeviceRequest.getCount()){
+            throw new GeneralException(RentalException.CANT_RESTOCK_WHEN_AVAILABLE_COUNT);
+        }
+
+    }
+
+}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #101 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 재입고 알림 저장 API  

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->

- Restock에 원하는 대여 기간을 저장하는 것이 필요해 보여서 ERD가 수정될 것 같습니다! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 가맹점 기기 재입고 요청 기능이 추가되었습니다. 사용자는 원하는 기간과 수량을 입력하여 재입고를 신청할 수 있습니다.

* **버그 수정**
  * 재입고 및 예약 시 가맹점이 소유한 기기 수를 초과할 수 없도록 검증이 강화되었습니다.
  * 예약 가능한 상황에서는 재입고 신청이 불가능하도록 제한이 추가되었습니다.
  * 예약 및 재입고 시 시작 날짜가 종료 날짜보다 앞서야 한다는 검증이 추가되어 날짜 관련 오류를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->