### PR TITLE
Feat: [BADA-166] 사용자 공유기 대여 내역 조회 API

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Reservation.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/entity/Reservation.java
@@ -48,6 +48,9 @@ public class Reservation extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime rentalEndDate;
 
+    @Column(nullable = false)
+    private Integer price;
+
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
 
@@ -63,6 +66,7 @@ public class Reservation extends BaseEntity {
                 .rentalEndDate(rentalEndDate)
                 .status(ReservationStatus.PENDING)
                 .store(store)
+                .price(10)
                 .build();
     }
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepository.java
@@ -1,0 +1,8 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import com.TwoSeaU.BaData.domain.user.dto.response.GetRentalResponse;
+import com.TwoSeaU.BaData.global.dto.CursorPageResponse;
+
+public interface ReservationQueryRepository {
+	CursorPageResponse<GetRentalResponse> getAllRentalsByCursor(final Long cursor, final int size, final Long userId);
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepositoryImpl.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepositoryImpl.java
@@ -21,9 +21,9 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
 	private final JPAQueryFactory queryFactory;
 
 	public CursorPageResponse<GetRentalResponse> getAllRentalsByCursor(final Long cursor, final int size, final Long userId) {
-		QReservation qReservation = QReservation.reservation;
-		QStore qStore = QStore.store;
-		BooleanBuilder where = new BooleanBuilder();
+		final QReservation qReservation = QReservation.reservation;
+		final QStore qStore = QStore.store;
+		final BooleanBuilder where = new BooleanBuilder();
 
 		if(cursor != null) {
 			where.and(qReservation.id.lt(cursor));
@@ -31,18 +31,18 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
 
 		where.and(qReservation.user.id.eq(userId));
 
-		List<Reservation> fetchedList = queryFactory.selectFrom(qReservation)
+		final List<Reservation> fetchedList = queryFactory.selectFrom(qReservation)
 			.leftJoin(qReservation.store, qStore).fetchJoin()
 			.where(where)
 			.orderBy(qReservation.id.desc())
 			.limit(size + 1)
 			.fetch();
 
-		boolean hasNext = fetchedList.size() > size;
-		List<Reservation> qReservationList = hasNext
+		final boolean hasNext = fetchedList.size() > size;
+		final List<Reservation> qReservationList = hasNext
 			? fetchedList.subList(0, size) : fetchedList;
 
-		List<GetRentalResponse> responseList = qReservationList.stream()
+		final List<GetRentalResponse> responseList = qReservationList.stream()
 			.map(reservation -> {
 				Store store = reservation.getStore();
 				if(store == null) {
@@ -53,7 +53,7 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
 			})
 			.toList();
 
-		Long nextCursor = responseList.isEmpty() ? null : responseList.get(responseList.size() - 1).getId();
+		final Long nextCursor = responseList.isEmpty() ? null : responseList.get(responseList.size() - 1).getId();
 
 		return CursorPageResponse.of(responseList, nextCursor, hasNext);
 	}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepositoryImpl.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepositoryImpl.java
@@ -4,8 +4,12 @@ import java.util.List;
 
 import com.TwoSeaU.BaData.domain.rental.entity.QReservation;
 import com.TwoSeaU.BaData.domain.rental.entity.Reservation;
+import com.TwoSeaU.BaData.domain.store.entity.QStore;
+import com.TwoSeaU.BaData.domain.store.entity.Store;
+import com.TwoSeaU.BaData.domain.store.exception.StoreException;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetRentalResponse;
 import com.TwoSeaU.BaData.global.dto.CursorPageResponse;
+import com.TwoSeaU.BaData.global.response.GeneralException;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -18,6 +22,7 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
 
 	public CursorPageResponse<GetRentalResponse> getAllRentalsByCursor(final Long cursor, final int size, final Long userId) {
 		QReservation qReservation = QReservation.reservation;
+		QStore qStore = QStore.store;
 		BooleanBuilder where = new BooleanBuilder();
 
 		if(cursor != null) {
@@ -27,6 +32,7 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
 		where.and(qReservation.user.id.eq(userId));
 
 		List<Reservation> fetchedList = queryFactory.selectFrom(qReservation)
+			.leftJoin(qReservation.store, qStore).fetchJoin()
 			.where(where)
 			.orderBy(qReservation.id.desc())
 			.limit(size + 1)
@@ -37,7 +43,14 @@ public class ReservationQueryRepositoryImpl implements ReservationQueryRepositor
 			? fetchedList.subList(0, size) : fetchedList;
 
 		List<GetRentalResponse> responseList = qReservationList.stream()
-			.map(GetRentalResponse::from)
+			.map(reservation -> {
+				Store store = reservation.getStore();
+				if(store == null) {
+					throw new GeneralException(StoreException.CANT_FIND_STORE);
+				}
+
+				return GetRentalResponse.from(reservation, store);
+			})
 			.toList();
 
 		Long nextCursor = responseList.isEmpty() ? null : responseList.get(responseList.size() - 1).getId();

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepositoryImpl.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationQueryRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.TwoSeaU.BaData.domain.rental.repository;
+
+import java.util.List;
+
+import com.TwoSeaU.BaData.domain.rental.entity.QReservation;
+import com.TwoSeaU.BaData.domain.rental.entity.Reservation;
+import com.TwoSeaU.BaData.domain.user.dto.response.GetRentalResponse;
+import com.TwoSeaU.BaData.global.dto.CursorPageResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ReservationQueryRepositoryImpl implements ReservationQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public CursorPageResponse<GetRentalResponse> getAllRentalsByCursor(final Long cursor, final int size, final Long userId) {
+		QReservation qReservation = QReservation.reservation;
+		BooleanBuilder where = new BooleanBuilder();
+
+		if(cursor != null) {
+			where.and(qReservation.id.lt(cursor));
+		}
+
+		where.and(qReservation.user.id.eq(userId));
+
+		List<Reservation> fetchedList = queryFactory.selectFrom(qReservation)
+			.where(where)
+			.orderBy(qReservation.id.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = fetchedList.size() > size;
+		List<Reservation> qReservationList = hasNext
+			? fetchedList.subList(0, size) : fetchedList;
+
+		List<GetRentalResponse> responseList = qReservationList.stream()
+			.map(GetRentalResponse::from)
+			.toList();
+
+		Long nextCursor = responseList.isEmpty() ? null : responseList.get(responseList.size() - 1).getId();
+
+		return CursorPageResponse.of(responseList, nextCursor, hasNext);
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/rental/repository/ReservationRepository.java
@@ -6,7 +6,7 @@ import com.TwoSeaU.BaData.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface ReservationRepository extends JpaRepository<Reservation,Long> {
+public interface ReservationRepository extends JpaRepository<Reservation,Long>, ReservationQueryRepository {
 
     @Query("select count(*) from Reservation r where r.store=:store and r.user=:user")
     int countByReservationAndStore(final Store store, final User user);

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import com.TwoSeaU.BaData.domain.user.dto.response.GetAllPurchasesResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetAllReportResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetFollowsResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetLikesStoreResponse;
+import com.TwoSeaU.BaData.domain.user.dto.response.GetRentalResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetSaleResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetSosResponse;
 import com.TwoSeaU.BaData.domain.user.enums.FollowType;
@@ -96,5 +97,13 @@ public class UserController {
 		@RequestParam(defaultValue = "10") int size,
 		@AuthenticationPrincipal User user) {
 		return ResponseEntity.ok().body(ApiResponse.success(userService.getAllLikesStoresByCursor(cursor, size, user.getUsername())));
+	}
+
+	@GetMapping("/rentals")
+	public ResponseEntity<ApiResponse<CursorPageResponse<GetRentalResponse>>> getAllRentalsByCursor(
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(defaultValue = "10") int size,
+		@AuthenticationPrincipal User user) {
+		return ResponseEntity.ok().body(ApiResponse.success(userService.getAllRentalsByCursor(cursor, size, user.getUsername())));
 	}
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetRentalResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetRentalResponse.java
@@ -1,0 +1,34 @@
+package com.TwoSeaU.BaData.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.TwoSeaU.BaData.domain.rental.entity.Reservation;
+import com.TwoSeaU.BaData.domain.rental.enums.ReservationStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetRentalResponse {
+	private Long id;
+	private String storeName;
+	private LocalDateTime rentalStartDate;
+	private Integer price;
+	private ReservationStatus reservationStatus;
+
+	public static GetRentalResponse from(final Reservation reservation) {
+		return GetRentalResponse.builder()
+			.id(reservation.getId())
+			.storeName(reservation.getStore().getName())
+			.rentalStartDate(reservation.getRentalStartDate())
+			.price(reservation.getPrice())
+			.reservationStatus(reservation.getStatus())
+			.build();
+	}
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetRentalResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetRentalResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.TwoSeaU.BaData.domain.rental.entity.Reservation;
 import com.TwoSeaU.BaData.domain.rental.enums.ReservationStatus;
+import com.TwoSeaU.BaData.domain.store.entity.Store;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,10 +23,10 @@ public class GetRentalResponse {
 	private Integer price;
 	private ReservationStatus reservationStatus;
 
-	public static GetRentalResponse from(final Reservation reservation) {
+	public static GetRentalResponse from(final Reservation reservation, final Store store) {
 		return GetRentalResponse.builder()
 			.id(reservation.getId())
-			.storeName(reservation.getStore().getName())
+			.storeName(store.getName())
 			.rentalStartDate(reservation.getRentalStartDate())
 			.price(reservation.getPrice())
 			.reservationStatus(reservation.getStatus())

--- a/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.TwoSeaU.BaData.domain.rental.repository.ReservationRepository;
 import com.TwoSeaU.BaData.domain.sos.repository.SosRepository;
 import com.TwoSeaU.BaData.domain.store.repository.StoreLikesRepository;
 import com.TwoSeaU.BaData.domain.trade.entity.Payment;
@@ -26,6 +27,7 @@ import com.TwoSeaU.BaData.domain.user.dto.response.GetFollowsResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetLikesPostResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetLikesStoreResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetPurchaseResponse;
+import com.TwoSeaU.BaData.domain.user.dto.response.GetRentalResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetReportResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetSaleResponse;
 import com.TwoSeaU.BaData.domain.user.dto.response.GetSosResponse;
@@ -51,6 +53,7 @@ public class UserService {
 	private final SosRepository sosRepository;
 	private final UserLikesRepository userLikesRepository;
 	private final StoreLikesRepository storeLikesRepository;
+	private final ReservationRepository reservationRepository;
 
 	public DataResponse getData(String username) {
 		User user = userRepository.findByUsername(username)
@@ -158,5 +161,12 @@ public class UserService {
 			.orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
 
 		return storeLikesRepository.getAllLikesStoresResponseByCursor(cursor, size, user.getId());
+	}
+
+	public CursorPageResponse<GetRentalResponse> getAllRentalsByCursor(final Long cursor, final int size, final String username) {
+		final User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+
+		return reservationRepository.getAllRentalsByCursor(cursor, size, user.getId());
 	}
 }


### PR DESCRIPTION
### **User description**
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #153 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 사용자 공유기 대여 내역 조회 API

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->
- Reservation 엔티티에 price 가 추가되었습니다.
- 우선 price 값을 Reservation에 10으로 고정되게 하였습니다.


___

### **PR Type**
enhancement


___

### **Description**
- 사용자 공유기 대여 내역 조회 API 구현

- `Reservation` 엔티티에 `price` 필드 추가

- `ReservationQueryRepository` 및 구현체 추가

- `UserController`에 대여 내역 조회 엔드포인트 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Reservation -- "price 필드 추가" --> ReservationEntity
  ReservationEntity -- "대여 내역 조회 로직 구현" --> ReservationQueryRepository
  ReservationQueryRepository -- "커서 페이징 구현" --> ReservationQueryRepositoryImpl
  UserController -- "대여 내역 조회 엔드포인트 추가" --> GetAllRentalsByCursor
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

