### PR TITLE
Feat: [BADA-198] 대여 날짜 빈값일 때 오늘로 설정

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceCustomRepositoryImpl.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceCustomRepositoryImpl.java
@@ -57,8 +57,8 @@ public class StoreDeviceCustomRepositoryImpl implements StoreDeviceCustomReposit
                                         .join(deviceReservation.reservation, reservation)
                                         .where(
                                                 deviceReservation.storeDevice.eq(storeDevice),
-                                                reservation.rentalStartDate.loe(rentalStartDate),
-                                                reservation.rentalEndDate.goe(rentalEndDate)
+                                                reservation.rentalStartDate.loe(rentalEndDate),
+                                                reservation.rentalEndDate.goe(rentalStartDate)
                                         )
                         ).sum()))
                 .from(storeDevice)

--- a/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceCustomRepositoryImpl.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceCustomRepositoryImpl.java
@@ -20,6 +20,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -40,6 +41,14 @@ public class StoreDeviceCustomRepositoryImpl implements StoreDeviceCustomReposit
     @Override
     public List<ShowStoreWithLeftDeviceResponse> findStoresInBoundingBox(final StoreMapSearchRequest storeMapSearchRequest){
 
+        LocalDateTime rentalStartDate = storeMapSearchRequest.getRentalStartDate();
+        LocalDateTime rentalEndDate = storeMapSearchRequest.getRentalEndDate();
+
+        if( rentalStartDate == null || rentalEndDate == null){
+            rentalStartDate = LocalDateTime.now();
+            rentalEndDate = LocalDate.now().atTime(23, 59, 59);
+        }
+
         return queryFactory.select(Projections.constructor(ShowStoreWithLeftDeviceResponse.class,
                         storeDevice.store,storeDevice.count.subtract(
                                 JPAExpressions
@@ -48,8 +57,8 @@ public class StoreDeviceCustomRepositoryImpl implements StoreDeviceCustomReposit
                                         .join(deviceReservation.reservation, reservation)
                                         .where(
                                                 deviceReservation.storeDevice.eq(storeDevice),
-                                                reservation.rentalStartDate.loe(storeMapSearchRequest.getRentalEndDate()),
-                                                reservation.rentalEndDate.goe(storeMapSearchRequest.getRentalStartDate())
+                                                reservation.rentalStartDate.loe(rentalStartDate),
+                                                reservation.rentalEndDate.goe(rentalEndDate)
                                         )
                         ).sum()))
                 .from(storeDevice)


### PR DESCRIPTION
### **User description**
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #190 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 대여 날짜 빈 값 일때 오늘로 설정 

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->


___

### **PR Type**
Enhancement


___

### **Description**
- 대여 날짜 빈 값일 때 오늘로 설정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  rentalDateCheck["대여 날짜 null 체크"] -- "null일 경우" --> setToday["오늘 날짜로 설정"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StoreDeviceCustomRepositoryImpl.java</strong><dd><code>대여 날짜 null 처리 및 쿼리 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/TwoSeaU/BaData/domain/store/repository/StoreDeviceCustomRepositoryImpl.java

<ul><li>대여 시작/종료 날짜가 null일 경우 오늘 날짜로 설정<br> <li> 대여 날짜 검사 로직 추가<br> <li> 쿼리 수정: 변수 사용으로 변경</ul>


</details>


  </td>
  <td><a href="https://github.com/Ureca-Final-Project-Team2/be_badata/pull/191/files#diff-60181f549f6da3a034343a857203e82fd01976764f89c4cbfa92a143180c9352">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

