### PR TITLE
Feat: [BADA-251] SOS 응답 시 받은 데이터량 항목 추가

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetSosResponse.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/user/dto/response/GetSosResponse.java
@@ -18,6 +18,7 @@ public class GetSosResponse {
 	private Long sosId;
 	private Long responderId;
 	private LocalDateTime createdAt;
+	private String dataAmount;
 	private Boolean isSuccess;
 
 	public static GetSosResponse from(final Sos sos) {
@@ -27,6 +28,7 @@ public class GetSosResponse {
 			.sosId(sos.getId())
 			.responderId(hasResponder ? sos.getResponder().getId() : null)
 			.createdAt(sos.getCreatedAt())
+			.dataAmount("100MB")
 			.isSuccess(hasResponder)
 			.build();
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #250 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] SOS 응답 시 받은 데이터량 항목 추가

### 🔍 리뷰 요청 사항

<!-- 리뷰어가 중점적으로 봐야 할 내용을 적어주세요. -->
- ResponseDTO에 받은 데이터량은 항상 100MB로 일정하기 때문에 dataamount에 100MB를 고정시켰습니다!