### PR TITLE
Feat: [BADA-338] 구매 후 신고 및 환불 기능 개발

### DIFF
--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/ReportController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.TwoSeaU.BaData.domain.trade.controller;
 
+import com.TwoSeaU.BaData.domain.trade.dto.request.SavePurchaseReportRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveReportRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.response.SaveReportResponse;
 import com.TwoSeaU.BaData.domain.trade.service.ReportService;
@@ -22,4 +23,8 @@ public class ReportController {
         return ResponseEntity.ok().body(ApiResponse.success(reportService.createReport(postId, saveReportRequest, user.getUsername())));
     }
 
+    @PostMapping("/Purchases/{postId}")
+    public ResponseEntity<ApiResponse<SaveReportResponse>> createPurchaseReport(@PathVariable Long postId, @Valid @RequestBody SavePurchaseReportRequest savePurchaseReportRequest, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok().body(ApiResponse.success(reportService.createPurchaseReport(postId, savePurchaseReportRequest, user.getUsername())));
+    }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/ReportController.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/controller/ReportController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/trades")
+@RequestMapping("/api/v1/trades/")
 public class ReportController {
     private final ReportService reportService;
 
@@ -23,7 +23,7 @@ public class ReportController {
         return ResponseEntity.ok().body(ApiResponse.success(reportService.createReport(postId, saveReportRequest, user.getUsername())));
     }
 
-    @PostMapping("/Purchases/{postId}")
+    @PostMapping("{postId}/reports/purchases")
     public ResponseEntity<ApiResponse<SaveReportResponse>> createPurchaseReport(@PathVariable Long postId, @Valid @RequestBody SavePurchaseReportRequest savePurchaseReportRequest, @AuthenticationPrincipal User user) {
         return ResponseEntity.ok().body(ApiResponse.success(reportService.createPurchaseReport(postId, savePurchaseReportRequest, user.getUsername())));
     }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SavePurchaseReportRequest.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SavePurchaseReportRequest.java
@@ -1,0 +1,13 @@
+package com.TwoSeaU.BaData.domain.trade.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SavePurchaseReportRequest {
+    @NotNull(message = "신고 사유는 필수 작성입니다.")
+    private String comment;
+}

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SavePurchaseReportRequest.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/dto/request/SavePurchaseReportRequest.java
@@ -4,9 +4,11 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SavePurchaseReportRequest {
     @NotNull(message = "신고 사유는 필수 작성입니다.")
     private String comment;

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Gifticon.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Gifticon.java
@@ -42,11 +42,11 @@ public class Gifticon extends Post{
         this.vector = vector;
     }
 
-    public void updateVector(double[] vector) {
+    public void updateVector(final double[] vector) {
         this.vector = vector;
     }
 
-    public void updateBarcodeViewTime(LocalDateTime barcodeViewTime) {
+    public void updateBarcodeViewTime(final LocalDateTime barcodeViewTime) {
         this.barcodeViewTime = barcodeViewTime;
     }
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Report.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/entity/Report.java
@@ -28,9 +28,11 @@ public class Report extends BaseEntity {
     private User user;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ReportStatus reportStatus;
 
     @Enumerated(EnumType.ORDINAL)
+    @Column(nullable = false)
     private ReportType reportTypeCode;
 
     private String reportReason;

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/enums/ReportType.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/enums/ReportType.java
@@ -6,7 +6,10 @@ public enum ReportType {
     RESELLING_HIGH_PRICE("나에게 구매 후 비싸게 재판매 하는 것 같아요"),
     ABOVE_MARKET_PRICE("정가보다 비싸요"),
     FREE_OR_MONEY_REQUEST("무료 나눔 및 금전 요구 글이에요"),
-    ETC("기타");
+    ETC("기타"),
+
+    AFTER_TRADE("거래 후 신고");
+
 
     private final String description;
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
@@ -48,7 +48,7 @@ public enum TradeException implements BaseException {
     RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3036, "추천 게시글 처리에 실패했습니다."),
     DUPLICATE_COUPON_NUMBER(HttpStatus.BAD_REQUEST, 3037, "이미 등록된 기프티콘입니다."),
     NOT_PURCHASED_GIFTICON(HttpStatus.BAD_REQUEST, 3038, "구매하지 않은 기프티콘은 조회할 수 없습니다."),
-    GIFTICON_NOT_FOUND(HttpStatus.NOT_FOUND, 3039, "데이터 게시글은 구매 후 신고할 수 없습니다."),
+    GIFTICON_NOT_FOUND(HttpStatus.NOT_FOUND, 3039, "신고하려는 게시글이 기프티콘이 아닙니다."),
     BARCODE_NOT_VIEWED(HttpStatus.BAD_REQUEST, 3040, "바코드를 조회하지 않은 기프티콘은 신고할 수 없습니다."),
     ;
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
@@ -48,6 +48,7 @@ public enum TradeException implements BaseException {
     RECOMMENDATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3036, "추천 게시글 처리에 실패했습니다."),
     DUPLICATE_COUPON_NUMBER(HttpStatus.BAD_REQUEST, 3037, "이미 등록된 기프티콘입니다."),
     NOT_PURCHASED_GIFTICON(HttpStatus.BAD_REQUEST, 3038, "구매하지 않은 기프티콘은 조회할 수 없습니다."),
+    GIFTICON_NOT_FOUND(HttpStatus.NOT_FOUND, 3039, "데이터 게시글은 구매 후 신고할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/exception/TradeException.java
@@ -49,6 +49,7 @@ public enum TradeException implements BaseException {
     DUPLICATE_COUPON_NUMBER(HttpStatus.BAD_REQUEST, 3037, "이미 등록된 기프티콘입니다."),
     NOT_PURCHASED_GIFTICON(HttpStatus.BAD_REQUEST, 3038, "구매하지 않은 기프티콘은 조회할 수 없습니다."),
     GIFTICON_NOT_FOUND(HttpStatus.NOT_FOUND, 3039, "데이터 게시글은 구매 후 신고할 수 없습니다."),
+    BARCODE_NOT_VIEWED(HttpStatus.BAD_REQUEST, 3040, "바코드를 조회하지 않은 기프티콘은 신고할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/GifticonCategoryRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/GifticonCategoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface GifticonCategoryRepository extends JpaRepository<GifticonCategory, Long> {
-    Optional<GifticonCategory> findByCategoryName(String categoryName);
+    Optional<GifticonCategory> findByCategoryName(final String categoryName);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/GifticonRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/GifticonRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface GifticonRepository extends JpaRepository<Gifticon,Long> {
 
-    List<Gifticon> findByIsSoldAndDeadLineGreaterThanEqual(final boolean isSold, final LocalDate time);
+    List<Gifticon> findByIsSoldAndIsDeletedAndDeadLineGreaterThanEqual(final boolean isSold, final boolean isDeleted, final LocalDate time);
     Boolean existsByCouponNumber(final String couponNumber);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PartnerRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PartnerRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PartnerRepository extends JpaRepository<Partner, Long> {
-    List<Partner> findByCategoryId(Long categoryId);
+    List<Partner> findByCategoryId(final Long categoryId);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PaymentQueryRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PaymentQueryRepository.java
@@ -9,5 +9,5 @@ public interface PaymentQueryRepository {
 
 	CursorPageResponse<GetPurchaseResponse> getAllPurchasesByCursor(final Long cursor, final int size, final Long userId);
 
-    List<Long> findBoughtPostIdByUserId(Long userId);
+    List<Long> findBoughtPostIdByUserId(final Long userId);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesQueryRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesQueryRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface PostLikesQueryRepository {
 	CursorPageResponse<GetLikesPostResponse> getAllLikesPostsByCursor(final Long cursor, final int size, final Long userId);
 
-	List<Long> findDistinctPostIdsByUserId(Long userId);
+	List<Long> findDistinctPostIdsByUserId(final Long userId);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostLikesRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PostLikesRepository extends JpaRepository<PostLikes, Long>, PostLikesQueryRepository{
-    Optional<PostLikes> findByUserIdAndPostId(Long userId, Long postId);
-    Boolean existsByUserIdAndPostId(Long userId, Long postId);
-    int countByPostId(Long postId);
-    int countByUserId(Long userId);
+    Optional<PostLikes> findByUserIdAndPostId(final Long userId, final Long postId);
+    Boolean existsByUserIdAndPostId(final Long userId, final Long postId);
+    int countByPostId(final Long postId);
+    int countByUserId(final Long userId);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/PostRepository.java
@@ -7,13 +7,10 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
     int countBySellerId(final Long sellerId);
-    List<Post> findTop5ByIsSoldAndIsDeletedOrderByCreatedAtDesc(final boolean isSold, final boolean isDeleted);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Post p WHERE p.id = :postId")

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/ReportRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/ReportRepository.java
@@ -2,10 +2,12 @@ package com.TwoSeaU.BaData.domain.trade.repository;
 
 import com.TwoSeaU.BaData.domain.trade.entity.Report;
 import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
+import com.TwoSeaU.BaData.domain.trade.enums.ReportType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long>, ReportQueryRepository {
 
-	boolean existsByUserIdAndPostId(Long userId, Long postId);
+	boolean existsByUserIdAndPostId(final Long userId, final Long postId);
+	boolean existsByUserIdAndPostIdAndReportType(final Long userId, final Long postId, final ReportType reportType);
 	Long countByUserIdAndReportStatus(final Long userId, final ReportStatus status);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/ReportRepository.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/repository/ReportRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReportRepository extends JpaRepository<Report, Long>, ReportQueryRepository {
 
 	boolean existsByUserIdAndPostId(final Long userId, final Long postId);
-	boolean existsByUserIdAndPostIdAndReportType(final Long userId, final Long postId, final ReportType reportType);
+	boolean existsByUserIdAndPostIdAndReportTypeCode(final Long userId, final Long postId, final ReportType reportType);
 	Long countByUserIdAndReportStatus(final Long userId, final ReportStatus status);
 }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PaymentService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PaymentService.java
@@ -20,6 +20,7 @@ import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
 import com.TwoSeaU.BaData.global.response.GeneralException;
 import com.siot.IamportRestClient.IamportClient;
 import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
 import com.siot.IamportRestClient.response.IamportResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -102,6 +103,15 @@ public class PaymentService {
         );
     }
 
+    private void cancelPayment(final String impUid) {
+        try{
+            iamportClient.cancelPaymentByImpUid(new CancelData(impUid, true));
+        }
+        catch (IamportResponseException | IOException e){
+            throw new GeneralException(TradeException.PAYMENT_FAILED);
+        }
+    }
+
     public GetValidatePaymentResponse validateIamport(final String impUid, final Long postId, final String username) throws IamportResponseException, IOException {
         IamportResponse<com.siot.IamportRestClient.response.Payment> portOnePayment = iamportClient.paymentByImpUid(impUid);
 
@@ -116,10 +126,12 @@ public class PaymentService {
                 .orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
 
         if (post.getIsDeleted()) {
+            cancelPayment(impUid);
             throw new GeneralException(TradeException.DELETED_POST_ACCESS_DENIED);
         }
 
         if (post.getIsSold()) {
+            cancelPayment(impUid);
             throw new GeneralException(TradeException.PAYMENT_DUPLICATE);
         }
 
@@ -131,10 +143,12 @@ public class PaymentService {
                 .orElseThrow(() -> new GeneralException(TradeException.PAYMENT_NOT_FOUND));
 
         if (payment.getAmount().compareTo(portOnePayment.getResponse().getAmount()) != 0) {
+            cancelPayment(impUid);
             throw new GeneralException(TradeException.PAYMENT_AMOUNT_MISMATCH);
         }
 
         if (payment.getUseCoin().intValue() > user.getCoin()) {
+            cancelPayment(impUid);
             throw new GeneralException(TradeException.COIN_NOT_ENOUGH);
         }
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PaymentService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/PaymentService.java
@@ -24,6 +24,7 @@ import com.siot.IamportRestClient.request.CancelData;
 import com.siot.IamportRestClient.response.IamportResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import  com.siot.IamportRestClient.request.PrepareData;
 
@@ -33,6 +34,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -108,6 +110,7 @@ public class PaymentService {
             iamportClient.cancelPaymentByImpUid(new CancelData(impUid, true));
         }
         catch (IamportResponseException | IOException e){
+            log.error("impUid {}에 대한 결제 환불에 실패했습니다. :", impUid, e);
             throw new GeneralException(TradeException.PAYMENT_FAILED);
         }
     }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/RecommendService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/RecommendService.java
@@ -81,7 +81,7 @@ public class RecommendService {
     private PostsResponse recommendContentBasedFiltering (User user) {
         double[] userVector = userProfileVectorizer.vectorizeUserProfile(user);
 
-        List<Gifticon> candidatePosts = gifticonRepository.findByIsSoldAndDeadLineGreaterThanEqual(false, LocalDate.now());
+        List<Gifticon> candidatePosts = gifticonRepository.findByIsSoldAndIsDeletedAndDeadLineGreaterThanEqual(false, false, LocalDate.now());
 
         List<RecommendationResult> results = candidatePosts.parallelStream()
                 .map(post -> {

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
@@ -82,7 +82,7 @@ public class ReportService {
         paymentRepository.findByUserIdAndPostIdAndPaymentStatus(user.getId(), post.getId(), PaymentStatus.PAID)
                 .orElseThrow(() -> new GeneralException(TradeException.PAYMENT_NOT_FOUND));
 
-        if (reportRepository.existsByUserIdAndPostIdAndReportType(user.getId(), post.getId(), ReportType.AFTER_TRADE)) {
+        if (reportRepository.existsByUserIdAndPostIdAndReportTypeCode(user.getId(), post.getId(), ReportType.AFTER_TRADE)) {
             throw new GeneralException(TradeException.REPORT_ALREADY_SUBMITTED);
         }
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
@@ -3,7 +3,7 @@ package com.TwoSeaU.BaData.domain.trade.service;
 import com.TwoSeaU.BaData.domain.trade.dto.request.SavePurchaseReportRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveReportRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.response.SaveReportResponse;
-import com.TwoSeaU.BaData.domain.trade.entity.Payment;
+import com.TwoSeaU.BaData.domain.trade.entity.Gifticon;
 import com.TwoSeaU.BaData.domain.trade.entity.Post;
 import com.TwoSeaU.BaData.domain.trade.entity.Report;
 import com.TwoSeaU.BaData.domain.trade.enums.PaymentStatus;
@@ -66,12 +66,15 @@ public class ReportService {
             throw new GeneralException(TradeException.NOT_PURCHASED_GIFTICON);
         }
 
-        if(!gifticonRepository.existsById(post.getId())){
-            throw new GeneralException(TradeException.GIFTICON_NOT_FOUND);
-        }
+        final Gifticon gifticon = gifticonRepository.findById(post.getId())
+                .orElseThrow(() -> new GeneralException(TradeException.GIFTICON_NOT_FOUND));
 
         if(post.getDeadLine().isBefore(LocalDate.now())) {
             throw new GeneralException(TradeException.EXPIRED_EXPIRATION_DATE);
+        }
+
+        if(gifticon.getBarcodeViewTime() == null){
+            throw new GeneralException(TradeException.BARCODE_NOT_VIEWED);
         }
 
         paymentRepository.findByUserIdAndPostIdAndPaymentStatus(user.getId(), post.getId(), PaymentStatus.PAID)

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
@@ -62,18 +62,18 @@ public class ReportService {
         final Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
 
-        if(!post.getIsSold()){
+        if (!post.getIsSold()) {
             throw new GeneralException(TradeException.NOT_PURCHASED_GIFTICON);
         }
 
         final Gifticon gifticon = gifticonRepository.findById(post.getId())
                 .orElseThrow(() -> new GeneralException(TradeException.GIFTICON_NOT_FOUND));
 
-        if(post.getDeadLine().isBefore(LocalDate.now())) {
+        if (post.getDeadLine().isBefore(LocalDate.now())) {
             throw new GeneralException(TradeException.EXPIRED_EXPIRATION_DATE);
         }
 
-        if(gifticon.getBarcodeViewTime() == null){
+        if (gifticon.getBarcodeViewTime() == null) {
             throw new GeneralException(TradeException.BARCODE_NOT_VIEWED);
         }
 

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
@@ -1,12 +1,17 @@
 package com.TwoSeaU.BaData.domain.trade.service;
 
+import com.TwoSeaU.BaData.domain.trade.dto.request.SavePurchaseReportRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.request.SaveReportRequest;
 import com.TwoSeaU.BaData.domain.trade.dto.response.SaveReportResponse;
+import com.TwoSeaU.BaData.domain.trade.entity.Payment;
 import com.TwoSeaU.BaData.domain.trade.entity.Post;
 import com.TwoSeaU.BaData.domain.trade.entity.Report;
+import com.TwoSeaU.BaData.domain.trade.enums.PaymentStatus;
 import com.TwoSeaU.BaData.domain.trade.enums.ReportStatus;
 import com.TwoSeaU.BaData.domain.trade.enums.ReportType;
 import com.TwoSeaU.BaData.domain.trade.exception.TradeException;
+import com.TwoSeaU.BaData.domain.trade.repository.GifticonRepository;
+import com.TwoSeaU.BaData.domain.trade.repository.PaymentRepository;
 import com.TwoSeaU.BaData.domain.trade.repository.PostRepository;
 import com.TwoSeaU.BaData.domain.trade.repository.ReportRepository;
 import com.TwoSeaU.BaData.domain.user.entity.User;
@@ -16,11 +21,15 @@ import com.TwoSeaU.BaData.global.response.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 public class ReportService {
     private final ReportRepository reportRepository;
     private final PostRepository postRepository;
+    private final GifticonRepository gifticonRepository;
+    private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;
 
     public SaveReportResponse createReport(final Long postId, final SaveReportRequest saveReportRequest, final String username) {
@@ -42,6 +51,38 @@ public class ReportService {
 
         final Report savedReport = reportRepository.save(Report.of(post, user, ReportStatus.QUESTION,
                 saveReportRequest.getReportType(), saveReportRequest.getComment()));
+
+        return SaveReportResponse.of(savedReport.getId());
+    }
+
+    public SaveReportResponse createPurchaseReport(final Long postId, final SavePurchaseReportRequest savePurchaseReportRequest, final String username) {
+        final User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));
+
+        final Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(TradeException.POST_NOT_FOUND));
+
+        if(!post.getIsSold()){
+            throw new GeneralException(TradeException.NOT_PURCHASED_GIFTICON);
+        }
+
+        if(!gifticonRepository.existsById(post.getId())){
+            throw new GeneralException(TradeException.GIFTICON_NOT_FOUND);
+        }
+
+        if(post.getDeadLine().isBefore(LocalDate.now())) {
+            throw new GeneralException(TradeException.EXPIRED_EXPIRATION_DATE);
+        }
+
+        paymentRepository.findByUserIdAndPostIdAndPaymentStatus(user.getId(), post.getId(), PaymentStatus.PAID)
+                .orElseThrow(() -> new GeneralException(TradeException.PAYMENT_NOT_FOUND));
+
+        if (reportRepository.existsByUserIdAndPostIdAndReportType(user.getId(), post.getId(), ReportType.AFTER_TRADE)) {
+            throw new GeneralException(TradeException.REPORT_ALREADY_SUBMITTED);
+        }
+
+        final Report savedReport = reportRepository.save(Report.of(post, user, ReportStatus.QUESTION,
+                ReportType.AFTER_TRADE, savePurchaseReportRequest.getComment()));
 
         return SaveReportResponse.of(savedReport.getId());
     }

--- a/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
+++ b/src/main/java/com/TwoSeaU/BaData/domain/trade/service/ReportService.java
@@ -18,6 +18,7 @@ import com.TwoSeaU.BaData.domain.user.entity.User;
 import com.TwoSeaU.BaData.domain.user.exception.UserException;
 import com.TwoSeaU.BaData.domain.user.repository.UserRepository;
 import com.TwoSeaU.BaData.global.response.GeneralException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -55,6 +56,7 @@ public class ReportService {
         return SaveReportResponse.of(savedReport.getId());
     }
 
+    @Transactional
     public SaveReportResponse createPurchaseReport(final Long postId, final SavePurchaseReportRequest savePurchaseReportRequest, final String username) {
         final User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new GeneralException(UserException.USER_NOT_FOUND));


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #346 
### 🚀 작업 내용

<!-- 주요 변경 사항이나 강조하고 싶은 내용을 설명해주세요. -->

- [x] 구매 후 신고 API 개발
- [x] (결제 완료 후 2차 서버 API 호출 시 이미 팔렸거나, 삭제된 경우) 환불 로직 추가

### 🔍 리뷰 요청 사항
거래 후 신고의 경우, 기프티콘의 유효기간이 이미 지난 경우 신고할 수 없게 했습니다.
또한 바코드 이미지를 열지 않은 게시글은 신고할 수 없도록 했습니다.
비지니스 로직 관련해서도 리뷰해주시면 감사하겠습니다.
